### PR TITLE
Bump package version to 1.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@npm/minify-registry-metadata",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@npm/minify-registry-metadata",
   "description": "minimal regsitry packuments. :corgi:",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "devDependencies": {
     "changes-stream": "^2.2.0",
     "concurrent-couch-follower": "^1.2.0",


### PR DESCRIPTION
There is already a version `1.0.2` published to the `@npm` internal registry. This pull-request is simply to bump past that so we can publish the latest code and get this package into another server for publication and deployment.

Current Version Published _(only version published)_
```
{
  "_id": "@npm/minify-registry-metadata@1.0.2",
  "_rev": "1-0d2d2137c336d98ab3fa872bc35994ff",
  "name": "@npm/minify-registry-metadata",
  "description": "minimal regsitry packuments. :corgi:",
  "dist-tags": {
    "latest": "1.0.2"
  },
  "versions": [
    "1.0.2"
  ],
  "maintainers": [
    "travis <ops@npmjs.com>"
  ],
  "time": {
    "modified": "2018-05-31T22:42:05.754Z",
    "created": "2018-05-31T22:42:05.754Z",
    "1.0.2": "2018-05-31T22:42:05.754Z"
  },
  ...
  "license": "ISC",
  "readmeFilename": "README.md",
  "_attachments": {},
  "_cached": true,
  "_contentLength": 0,
  "version": "1.0.2",
  "devDependencies": {
    "changes-stream": "^2.2.0",
    "concurrent-couch-follower": "^1.2.0",
    "normalize-registry-metadata": "^1.1.2",
    "request": "^2.80.0",
    "tape": "^4.6.3"
  },
  "main": "index.js",
  "scripts": {
    "test": "tape test/*.js"
  },
  "gitHead": "6580f3cf036e36dc9507d3e7c06f7e7e19033da1",
  "_npmVersion": "6.0.1",
  "_nodeVersion": "8.9.1",
  "_npmUser": "travis <ops@npmjs.com>",
  ...
}
```