### PR TITLE
PR for minify-registry-metadata  to handle sequence id in string format

### DIFF
--- a/integration.js
+++ b/integration.js
@@ -1,4 +1,4 @@
-
+const assert = require('assert')
 var changes = require('concurrent-couch-follower')
 var normalize = require('normalize-registry-metadata')
 var minify = require('./')
@@ -47,7 +47,7 @@ changes(function(data,done){
     //console.log(diff+'\t'+saved)
   }
 
-  if(data.seq >= 997485) {
+  if(getIntegerSequence(data.seq) >= 997485) {
 
     console.log('finished')
     report()
@@ -69,4 +69,11 @@ function report(){
     console.log('min doc size:',size)
     var total = Date.now()-start 
     console.log('elapsed: ',total,"\n")
+}
+
+function getIntegerSequence (sequence) {
+  const sequenceNumber = typeof sequence === 'string' ? sequence.split('-')[0] : sequence
+  const intSequence = parseInt(sequenceNumber, 10)
+  assert(intSequence >= 0, `Received invalid sequence from couchdb: ${sequence}`)
+  return intSequence
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "minify-registry-metadata",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "minify-registry-metadata",
   "description": "minimal regsitry packuments. :corgi:",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "devDependencies": {
     "changes-stream": "^2.2.0",
     "concurrent-couch-follower": "^1.2.0",


### PR DESCRIPTION
**What/Why**
As a part of [github/npm#6983](https://github.com/github/npm/issues/6983) we need to handle Sequence ID in both number and string format which is required for CouchDB version upgrade.

**References**  
[github/npm#7039](https://github.com/github/npm/issues/7039)